### PR TITLE
Skip translation when PO file is not found

### DIFF
--- a/lib/jekyll/l10n/asciidoctor_l10n_tree_processor.rb
+++ b/lib/jekyll/l10n/asciidoctor_l10n_tree_processor.rb
@@ -28,6 +28,7 @@ module Jekyll
 
           po_file_path = Jekyll::L10n::Util.resolve_po_path(unit.source_path, @jekyll_l10n_config.po_base_dir)
           po = @po_repository.load_file(po_file_path.to_path)
+          next if po.nil?
           entry = po[unit.text]
           unless entry.nil?
             if usable_translation?(entry, accept_mt)

--- a/lib/jekyll/l10n/document_processor.rb
+++ b/lib/jekyll/l10n/document_processor.rb
@@ -22,6 +22,7 @@ module Jekyll
           document_path = @jekyll_document.relative_path
           po_file_path = Jekyll::L10n::Util.resolve_po_path(document_path, @jekyll_l10n_config.po_base_dir)
           po = @po_repository.load_file(po_file_path.to_path)
+          return if po.nil?
           accept_mt = @jekyll_l10n_config.accept_mt
           @jekyll_document.data['title'] = resolve_translation(po, @jekyll_document.data['title'], accept_mt)
           @jekyll_document.data['synopsis'] = resolve_translation(po, @jekyll_document.data['synopsis'], accept_mt)

--- a/spec/jekyll/l10n/document_processor_spec.rb
+++ b/spec/jekyll/l10n/document_processor_spec.rb
@@ -44,6 +44,23 @@ describe Jekyll::L10n::DocumentProcessor do
     expect(data['synopsis']).to eq 'Untranslated synopsis'
   end
 
+  it 'keeps original values when PO file does not exist' do
+    jekyll_document = double("jekyll_document")
+    data = {
+      'asciidoc' => true,
+      'title' => 'Some Title',
+      'synopsis' => 'Some synopsis'
+    }
+    allow(jekyll_document).to receive(:data).and_return(data)
+    allow(jekyll_document).to receive(:relative_path).and_return('nonexistent.adoc')
+
+    processor = Jekyll::L10n::DocumentProcessor.new(jekyll_document, @config)
+    processor.translate
+
+    expect(data['title']).to eq 'Some Title'
+    expect(data['synopsis']).to eq 'Some synopsis'
+  end
+
   it 'skips non-asciidoc documents' do
     jekyll_document = double("jekyll_document")
     data = {


### PR DESCRIPTION
## Summary
- Add nil check for `po` in `AsciidoctorL10nTreeProcessor#translate` to prevent crash when PO file does not exist
- When a new AsciiDoc file is added upstream but the PO file has not been generated yet, the original text is kept instead of crashing