### PR TITLE
Make PO file language configurable via L10N_LANGUAGE

### DIFF
--- a/lib/jekyll/l10n/l10n_config.rb
+++ b/lib/jekyll/l10n/l10n_config.rb
@@ -20,6 +20,10 @@ module Jekyll
         @jekyll_config&.[]('l10n')&.[]('po')&.[]('base_dir') || @jekyll_config&.[]('l10n')&.[]('po')&.[]('baseDir') || ENV['L10N_PO_BASE_DIR']
       end
 
+      def language
+        @jekyll_config&.[]('l10n')&.[]('language') || ENV['L10N_LANGUAGE']
+      end
+
       def accept_mt
         value = @jekyll_config&.[]('l10n')&.[]('accept_mt') || ENV['ACCEPT_MT']
         return [] if value.nil? || value.empty?

--- a/lib/jekyll/l10n/model/po.rb
+++ b/lib/jekyll/l10n/model/po.rb
@@ -10,37 +10,15 @@ module Jekyll
 
         include Asciidoctor::Logging
 
-        def initialize(path, po_base_dir)
-          @path = path
-          @po_base_dir = po_base_dir
-          dirname = Pathname(path).dirname
-          unless dirname.exist?
-            raise "Parent directory #{dirname} doesn't exist."
-          end
-
-          @msgid_exact_map = load_po_object(path)
-          @msgid_normalized_map = {}
-          @msgid_exact_map.each do |entry|
-            if entry.msgid.is_a?(String)
-              normalized_message_id = entry.msgid.gsub(".\n", ".  ").gsub("\n", " ")
-              @msgid_normalized_map[normalized_message_id] = entry
-            end
-          end
-          header = GetText::POEntry.new(:normal)
-          header.msgid = ""
-          header.msgstr = <<-EOS
-Language: ja_JP
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
-X-Generator: jekyll-l10n
-          EOS
-
-          unless @msgid_exact_map.has_key?(header.msgid)
-            @msgid_exact_map[header.msgid] = header
-          end
-
+        def self.load(path, po_base_dir)
+          new(path, po_base_dir)
         end
+
+        def self.create(path, po_base_dir, locale)
+          new(path, po_base_dir, locale: locale)
+        end
+
+        private_class_method :new
 
         attr_reader :path
 
@@ -55,7 +33,6 @@ X-Generator: jekyll-l10n
             nil
           end
         end
-
 
         def update_entries(units)
           entries = []
@@ -95,7 +72,49 @@ X-Generator: jekyll-l10n
           @msgid_exact_map = po
         end
 
-        private def merge_extracted_comment(existing_comment, type_comment)
+        def write(file)
+          file.write(@msgid_exact_map.to_s)
+        end
+
+        def inspect
+          @path
+        end
+
+        private
+
+        def initialize(path, po_base_dir, locale: nil)
+          @path = path
+          @po_base_dir = po_base_dir
+          dirname = Pathname(path).dirname
+          unless dirname.exist?
+            raise "Parent directory #{dirname} doesn't exist."
+          end
+
+          @msgid_exact_map = load_po_object(path)
+          @msgid_normalized_map = {}
+          @msgid_exact_map.each do |entry|
+            if entry.msgid.is_a?(String)
+              normalized_message_id = entry.msgid.gsub(".\n", ".  ").gsub("\n", " ")
+              @msgid_normalized_map[normalized_message_id] = entry
+            end
+          end
+
+          unless @msgid_exact_map.has_key?("")
+            raise ArgumentError, "locale is required when creating a new PO file: #{path}" if locale.nil?
+            header = GetText::POEntry.new(:normal)
+            header.msgid = ""
+            header.msgstr = <<~EOS
+              Language: #{locale}
+              MIME-Version: 1.0
+              Content-Type: text/plain; charset=UTF-8
+              Content-Transfer-Encoding: 8bit
+              X-Generator: jekyll-l10n
+            EOS
+            @msgid_exact_map[header.msgid] = header
+          end
+        end
+
+        def merge_extracted_comment(existing_comment, type_comment)
           return type_comment if existing_comment.nil? || existing_comment.empty?
 
           # Remove old type: line if present, keep other lines (e.g., mt: gemini)
@@ -106,15 +125,7 @@ X-Generator: jekyll-l10n
           [type_comment, *non_type_lines].join("\n")
         end
 
-        def write(file)
-          file.write(@msgid_exact_map.to_s)
-        end
-
-        def inspect
-          @path
-        end
-
-        private def load_po_object(path)
+        def load_po_object(path)
           po = GetText::PO.new
           if Pathname.new(path).exist?
               parser = GetText::POParser.new

--- a/lib/jekyll/l10n/po_repository.rb
+++ b/lib/jekyll/l10n/po_repository.rb
@@ -11,13 +11,14 @@ module Jekyll
       def initialize(config)
         @po_map = Hash.new
         @po_base_dir = config.po_base_dir
+        @language = config.language
       end
 
       def load_file(path)
         po = @po_map[path.to_sym]
         if po.nil? # new file path
           if Pathname.new(path).exist?
-            po = Jekyll::L10n::Model::Po.new(path, @po_base_dir)
+            po = Jekyll::L10n::Model::Po.load(path, @po_base_dir)
             @po_map[path.to_sym] = po
             return po
           else
@@ -33,7 +34,7 @@ module Jekyll
       end
 
       def create_file(path)
-        po = Jekyll::L10n::Model::Po.new(path, @po_base_dir)
+        po = Jekyll::L10n::Model::Po.create(path, @po_base_dir, @language)
         @po_map[path.to_sym] = po
       end
 

--- a/spec/test/test_config.rb
+++ b/spec/test/test_config.rb
@@ -14,6 +14,10 @@ class TestConfig
     Pathname.new("sample/po").expand_path(File.dirname(File.dirname(__FILE__))).to_path
   end
 
+  def language
+    "ja_JP"
+  end
+
   def accept_mt
     @accept_mt || []
   end


### PR DESCRIPTION
## Summary

- The `Language` header in PO files was hardcoded to `ja_JP`, which would produce incorrect headers for non-Japanese projects (e.g. `pt_BR`)
- The old toolchain (quarkus-l10n-utils) worked around this by running `msgcat --lang=<locale>` during normalization, but tsuji does not include the `--lang` flag
- Add a `language` config option to `L10nConfig`, readable from Jekyll config (`l10n.language`) or `L10N_LANGUAGE` environment variable
- Introduce `Po.load` and `Po.create` factory methods to guarantee the Po invariant (header always present): `Po.load` relies on the existing file's header, `Po.create` requires a language to generate one. The constructor is now private.